### PR TITLE
fix business rule to add item in shopping cart only if not already in

### DIFF
--- a/src/main/java/com/e3gsix/fiap/tech_challenge_5_shopping_cart/model/entity/ShoppingCart.java
+++ b/src/main/java/com/e3gsix/fiap/tech_challenge_5_shopping_cart/model/entity/ShoppingCart.java
@@ -52,7 +52,17 @@ public class ShoppingCart {
     }
 
     public void addItem(ShoppingCartItem shoppingCartItem) {
-        this.shoppingCartItems.add(shoppingCartItem);
+        Optional<ShoppingCartItem> alreadyInCartItem = this.shoppingCartItems.stream()
+                .filter(it -> it.getItemId() == shoppingCartItem.getItemId())
+                .findFirst();
+
+        if (alreadyInCartItem.isEmpty()) {
+            this.shoppingCartItems.add(shoppingCartItem);
+            return;
+        }
+
+        ShoppingCartItem itemToUpdate = alreadyInCartItem.get();
+        itemToUpdate.setQuantity(itemToUpdate.getQuantity() + shoppingCartItem.getQuantity());
     }
 
     public ShoppingCartStatus getStatus() {


### PR DESCRIPTION
Whether some item already exists in the active shopping cart it'll not be added in duplicity, just increase the quantity of this item.